### PR TITLE
Fix CLI robustness, add DI + image sending

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -12,10 +12,11 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/mdp/qrterminal"
+	"github.com/vicentereig/whatsapp-cli/internal/types"
 	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/store/sqlstore"
-	"go.mau.fi/whatsmeow/types"
+	waTypes "go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
 	"google.golang.org/protobuf/proto"
@@ -25,8 +26,8 @@ type WAClient struct {
 	client          *whatsmeow.Client
 	storeDir        string
 	eventHandler    func(interface{})
-	contactLookup   func(ctx context.Context, user types.JID) (types.ContactInfo, error)
-	groupInfoLookup func(ctx context.Context, jid types.JID) (*types.GroupInfo, error)
+	contactLookup   func(ctx context.Context, user waTypes.JID) (waTypes.ContactInfo, error)
+	groupInfoLookup func(ctx context.Context, jid waTypes.JID) (*waTypes.GroupInfo, error)
 }
 
 type MediaInfo struct {
@@ -52,15 +53,6 @@ type MessageDetails struct {
 	Media     *MediaInfo
 }
 
-type MediaDownloadRequest struct {
-	DirectPath    string
-	MediaKey      []byte
-	FileSHA256    []byte
-	FileEncSHA256 []byte
-	FileLength    uint64
-	MediaType     string
-	MimeType      string
-}
 
 func NewWAClient(storeDir string) (*WAClient, error) {
 	// Create store directory
@@ -167,26 +159,26 @@ func (w *WAClient) AddEventHandler(handler func(interface{})) {
 	w.client.AddEventHandler(handler)
 }
 
-func contactLookupFunc(cli *whatsmeow.Client) func(ctx context.Context, user types.JID) (types.ContactInfo, error) {
+func contactLookupFunc(cli *whatsmeow.Client) func(ctx context.Context, user waTypes.JID) (waTypes.ContactInfo, error) {
 	if cli == nil || cli.Store == nil || cli.Store.Contacts == nil {
 		return nil
 	}
-	return func(ctx context.Context, user types.JID) (types.ContactInfo, error) {
+	return func(ctx context.Context, user waTypes.JID) (waTypes.ContactInfo, error) {
 		return cli.Store.Contacts.GetContact(ctx, user)
 	}
 }
 
-func groupInfoLookupFunc(cli *whatsmeow.Client) func(ctx context.Context, jid types.JID) (*types.GroupInfo, error) {
+func groupInfoLookupFunc(cli *whatsmeow.Client) func(ctx context.Context, jid waTypes.JID) (*waTypes.GroupInfo, error) {
 	if cli == nil {
 		return nil
 	}
-	return func(ctx context.Context, jid types.JID) (*types.GroupInfo, error) {
+	return func(ctx context.Context, jid waTypes.JID) (*waTypes.GroupInfo, error) {
 		info, err := cli.GetGroupInfo(ctx, jid)
 		return info, err
 	}
 }
 
-func bestContactName(info types.ContactInfo) string {
+func bestContactName(info waTypes.ContactInfo) string {
 	if !info.Found {
 		return ""
 	}
@@ -214,10 +206,10 @@ func (w *WAClient) ResolveChatName(ctx context.Context, chatJID string, msg *eve
 	}
 	fallback := chatJID
 
-	parsed, err := types.ParseJID(chatJID)
+	parsed, err := waTypes.ParseJID(chatJID)
 	if err == nil {
 		// Group chats
-		if parsed.Server == types.GroupServer || parsed.IsBroadcastList() {
+		if parsed.Server == waTypes.GroupServer || parsed.IsBroadcastList() {
 			if w.groupInfoLookup != nil {
 				if info, err := w.groupInfoLookup(ctx, parsed); err == nil && info != nil {
 					if name := strings.TrimSpace(info.GroupName.Name); name != "" {
@@ -258,14 +250,14 @@ func (w *WAClient) StartSync(ctx context.Context, eventHandler func(interface{})
 	return nil
 }
 
-func parseJID(recipient string) (types.JID, error) {
+func parseJID(recipient string) (waTypes.JID, error) {
 	// If already a JID, parse it
 	if contains(recipient, "@") {
-		return types.ParseJID(recipient)
+		return waTypes.ParseJID(recipient)
 	}
 
 	// Otherwise, assume it's a phone number
-	return types.JID{
+	return waTypes.JID{
 		User:   recipient,
 		Server: "s.whatsapp.net",
 	}, nil
@@ -280,7 +272,7 @@ func contains(s, substr string) bool {
 	return false
 }
 
-func (w *WAClient) DownloadMediaToFile(ctx context.Context, req MediaDownloadRequest, targetPath string) (int64, error) {
+func (w *WAClient) DownloadMediaToFile(ctx context.Context, req types.MediaDownloadRequest, targetPath string) (int64, error) {
 	if w == nil || w.client == nil {
 		return 0, fmt.Errorf("whatsapp client is not initialized")
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -200,7 +200,13 @@ func bestContactName(info waTypes.ContactInfo) string {
 	return ""
 }
 
-func (w *WAClient) ResolveChatName(ctx context.Context, chatJID string, msg *events.Message) string {
+func (w *WAClient) ResolveChatName(ctx context.Context, chatJID string, evt interface{}) string {
+	// Type assert to *events.Message if provided
+	var msg *events.Message
+	if evt != nil {
+		msg, _ = evt.(*events.Message)
+	}
+
 	if chatJID == "" && msg != nil {
 		chatJID = msg.Info.Chat.String()
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"mime"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,11 +104,10 @@ func (w *WAClient) Authenticate(ctx context.Context) error {
 
 	for evt := range qrChan {
 		if evt.Event == "code" {
-			fmt.Println("\nScan this QR code with your WhatsApp app:")
-			// Use Medium error correction and compact output
-			qrterminal.GenerateHalfBlock(evt.Code, qrterminal.M, os.Stdout)
+			fmt.Fprintln(os.Stderr, "\nScan this QR code with your WhatsApp app:")
+			qrterminal.GenerateHalfBlock(evt.Code, qrterminal.M, os.Stderr)
 		} else if evt.Event == "success" {
-			fmt.Println("\n✓ Successfully authenticated!")
+			fmt.Fprintln(os.Stderr, "\n✓ Successfully authenticated!")
 			return nil
 		}
 	}
@@ -137,22 +137,71 @@ func (w *WAClient) Disconnect() {
 	}
 }
 
-func (w *WAClient) SendMessage(ctx context.Context, recipient, message string) error {
+func (w *WAClient) SendMessage(ctx context.Context, recipient, message string) (string, error) {
 	if !w.client.IsConnected() {
-		return fmt.Errorf("not connected to WhatsApp")
+		return "", fmt.Errorf("not connected to WhatsApp")
 	}
 
 	recipientJID, err := parseJID(recipient)
 	if err != nil {
-		return err
+		return "", fmt.Errorf("parsing recipient: %w", err)
 	}
 
-	msg := &waProto.Message{
+	resp, err := w.client.SendMessage(ctx, recipientJID, &waProto.Message{
 		Conversation: proto.String(message),
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+func (w *WAClient) SendImageMessage(ctx context.Context, recipient, imagePath, caption string) (string, error) {
+	if !w.client.IsConnected() {
+		return "", fmt.Errorf("not connected to WhatsApp")
 	}
 
-	_, err = w.client.SendMessage(ctx, recipientJID, msg)
-	return err
+	recipientJID, err := parseJID(recipient)
+	if err != nil {
+		return "", fmt.Errorf("parsing recipient: %w", err)
+	}
+
+	data, err := os.ReadFile(imagePath)
+	if err != nil {
+		return "", fmt.Errorf("reading image file: %w", err)
+	}
+
+	mimeType := mimeTypeFromExtension(imagePath)
+
+	uploadResp, err := w.client.Upload(ctx, data, whatsmeow.MediaImage)
+	if err != nil {
+		return "", fmt.Errorf("uploading image: %w", err)
+	}
+
+	sendResp, err := w.client.SendMessage(ctx, recipientJID, &waProto.Message{
+		ImageMessage: &waProto.ImageMessage{
+			Caption:       proto.String(caption),
+			Mimetype:      proto.String(mimeType),
+			URL:           &uploadResp.URL,
+			DirectPath:    &uploadResp.DirectPath,
+			MediaKey:      uploadResp.MediaKey,
+			FileEncSHA256: uploadResp.FileEncSHA256,
+			FileSHA256:    uploadResp.FileSHA256,
+			FileLength:    &uploadResp.FileLength,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("sending image message: %w", err)
+	}
+	return sendResp.ID, nil
+}
+
+func mimeTypeFromExtension(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	if mtype := mime.TypeByExtension(ext); mtype != "" {
+		return mtype
+	}
+	return "image/jpeg"
 }
 
 func (w *WAClient) AddEventHandler(handler func(interface{})) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -258,7 +258,7 @@ func (w *WAClient) StartSync(ctx context.Context, eventHandler func(interface{})
 
 func parseJID(recipient string) (waTypes.JID, error) {
 	// If already a JID, parse it
-	if contains(recipient, "@") {
+	if strings.Contains(recipient, "@") {
 		return waTypes.ParseJID(recipient)
 	}
 
@@ -269,14 +269,6 @@ func parseJID(recipient string) (waTypes.JID, error) {
 	}, nil
 }
 
-func contains(s, substr string) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] == substr[0] {
-			return true
-		}
-	}
-	return false
-}
 
 func (w *WAClient) DownloadMediaToFile(ctx context.Context, req types.MediaDownloadRequest, targetPath string) (int64, error) {
 	if w == nil || w.client == nil {

--- a/internal/commands/behavioral_test.go
+++ b/internal/commands/behavioral_test.go
@@ -1,0 +1,231 @@
+package commands
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vicentereig/whatsapp-cli/internal/store"
+)
+
+// Helper to create string pointer
+func ptr(s string) *string {
+	return &s
+}
+
+// Response is the standard JSON response format
+type Response struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data"`
+	Error   *string         `json:"error"`
+}
+
+func parseResponse(t *testing.T, result string) Response {
+	t.Helper()
+	var resp Response
+	err := json.Unmarshal([]byte(result), &resp)
+	require.NoError(t, err, "response should be valid JSON: %s", result)
+	return resp
+}
+
+// TestListMessages_FiltersByChat verifies that --chat flag filters messages correctly.
+// This is the bug we fixed in PR #8.
+func TestListMessages_FiltersByChat(t *testing.T) {
+	targetJID := "target@s.whatsapp.net"
+	otherJID := "other@s.whatsapp.net"
+
+	allMessages := []store.Message{
+		{ID: "1", ChatJID: targetJID, Content: "hello from target", Timestamp: time.Now()},
+		{ID: "2", ChatJID: otherJID, Content: "hello from other", Timestamp: time.Now()},
+		{ID: "3", ChatJID: targetJID, Content: "another from target", Timestamp: time.Now()},
+	}
+
+	mockStore := &MockMessageStore{
+		ListMessagesFunc: func(params store.ListMessagesParams) ([]store.Message, error) {
+			// Simulate filtering behavior
+			if params.ChatJID != nil {
+				var filtered []store.Message
+				for _, m := range allMessages {
+					if m.ChatJID == *params.ChatJID {
+						filtered = append(filtered, m)
+					}
+				}
+				return filtered, nil
+			}
+			return allMessages, nil
+		},
+	}
+
+	app := NewAppWithDeps(&MockWAClient{}, mockStore, "/tmp", "test")
+
+	// When: ListMessages called with chat filter
+	result := app.ListMessages(ptr(targetJID), nil, 10, 0)
+
+	// Then: Only messages from target chat are returned
+	resp := parseResponse(t, result)
+	require.True(t, resp.Success, "should succeed")
+
+	var messages []store.Message
+	err := json.Unmarshal(resp.Data, &messages)
+	require.NoError(t, err)
+	require.Len(t, messages, 2, "should return only 2 messages from target chat")
+
+	for _, m := range messages {
+		require.Equal(t, targetJID, m.ChatJID, "all messages should be from target chat")
+	}
+}
+
+// TestListMessages_RespectsLimit verifies that --limit flag is honored.
+func TestListMessages_RespectsLimit(t *testing.T) {
+	allMessages := []store.Message{
+		{ID: "1", Content: "msg1", Timestamp: time.Now()},
+		{ID: "2", Content: "msg2", Timestamp: time.Now()},
+		{ID: "3", Content: "msg3", Timestamp: time.Now()},
+		{ID: "4", Content: "msg4", Timestamp: time.Now()},
+		{ID: "5", Content: "msg5", Timestamp: time.Now()},
+	}
+
+	var capturedLimit int
+	mockStore := &MockMessageStore{
+		ListMessagesFunc: func(params store.ListMessagesParams) ([]store.Message, error) {
+			capturedLimit = params.Limit
+			// Simulate limit behavior
+			if params.Limit > 0 && params.Limit < len(allMessages) {
+				return allMessages[:params.Limit], nil
+			}
+			return allMessages, nil
+		},
+	}
+
+	app := NewAppWithDeps(&MockWAClient{}, mockStore, "/tmp", "test")
+
+	// When: ListMessages called with limit=2
+	result := app.ListMessages(nil, nil, 2, 0)
+
+	// Then: Only 2 messages returned and limit was passed to store
+	resp := parseResponse(t, result)
+	require.True(t, resp.Success)
+	require.Equal(t, 2, capturedLimit, "limit should be passed to store")
+
+	var messages []store.Message
+	err := json.Unmarshal(resp.Data, &messages)
+	require.NoError(t, err)
+	require.Len(t, messages, 2, "should return only 2 messages")
+}
+
+// TestDownloadMedia_MissingMessage verifies proper error for non-existent message.
+func TestDownloadMedia_MissingMessage(t *testing.T) {
+	mockStore := &MockMessageStore{
+		GetMessageForDownloadFunc: func(id string, chatJID *string) (store.MessageDownloadInfo, error) {
+			return store.MessageDownloadInfo{}, sql.ErrNoRows
+		},
+	}
+
+	app := NewAppWithDeps(&MockWAClient{}, mockStore, "/tmp", "test")
+
+	// When: DownloadMedia called for non-existent message
+	result := app.DownloadMedia(context.Background(), "nonexistent123", nil, "")
+
+	// Then: Returns error with proper message
+	resp := parseResponse(t, result)
+	require.False(t, resp.Success, "should fail")
+	require.NotNil(t, resp.Error)
+	require.Contains(t, *resp.Error, "not found", "error should indicate message not found")
+}
+
+// TestDownloadMedia_EmptyMessageID verifies proper error for empty message ID.
+func TestDownloadMedia_EmptyMessageID(t *testing.T) {
+	app := NewAppWithDeps(&MockWAClient{}, &MockMessageStore{}, "/tmp", "test")
+
+	// When: DownloadMedia called with empty message ID
+	result := app.DownloadMedia(context.Background(), "", nil, "")
+
+	// Then: Returns error
+	resp := parseResponse(t, result)
+	require.False(t, resp.Success, "should fail")
+	require.NotNil(t, resp.Error)
+	require.Contains(t, *resp.Error, "required", "error should indicate ID is required")
+}
+
+// TestDownloadMedia_NoMedia verifies proper error when message has no media.
+func TestDownloadMedia_NoMedia(t *testing.T) {
+	mockStore := &MockMessageStore{
+		GetMessageForDownloadFunc: func(id string, chatJID *string) (store.MessageDownloadInfo, error) {
+			// Return message with no media info
+			return store.MessageDownloadInfo{
+				ID:      id,
+				ChatJID: "chat@jid",
+				// No MediaType, DirectPath, or MediaKey
+			}, nil
+		},
+	}
+
+	app := NewAppWithDeps(&MockWAClient{}, mockStore, "/tmp", "test")
+
+	// When: DownloadMedia called for message without media
+	result := app.DownloadMedia(context.Background(), "textonly123", nil, "")
+
+	// Then: Returns error indicating no media
+	resp := parseResponse(t, result)
+	require.False(t, resp.Success, "should fail")
+	require.NotNil(t, resp.Error)
+	require.Contains(t, *resp.Error, "no downloadable media", "error should indicate no media")
+}
+
+// TestSearchContacts_ReturnsResults verifies contact search works.
+func TestSearchContacts_ReturnsResults(t *testing.T) {
+	mockStore := &MockMessageStore{
+		SearchContactsFunc: func(query string) ([]store.Contact, error) {
+			if query == "john" {
+				return []store.Contact{
+					{Name: "John Doe", PhoneNumber: "1234567890", JID: "1234567890@s.whatsapp.net"},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	app := NewAppWithDeps(&MockWAClient{}, mockStore, "/tmp", "test")
+
+	// When: SearchContacts called with query
+	result := app.SearchContacts("john")
+
+	// Then: Returns matching contacts
+	resp := parseResponse(t, result)
+	require.True(t, resp.Success)
+
+	var contacts []store.Contact
+	err := json.Unmarshal(resp.Data, &contacts)
+	require.NoError(t, err)
+	require.Len(t, contacts, 1)
+	require.Equal(t, "John Doe", contacts[0].Name)
+}
+
+// TestListChats_ReturnsChats verifies chat listing works.
+func TestListChats_ReturnsChats(t *testing.T) {
+	mockStore := &MockMessageStore{
+		ListChatsFunc: func(params store.ListChatsParams) ([]store.Chat, error) {
+			return []store.Chat{
+				{JID: "chat1@jid", Name: "Chat One", LastMessageTime: time.Now()},
+				{JID: "chat2@jid", Name: "Chat Two", LastMessageTime: time.Now()},
+			}, nil
+		},
+	}
+
+	app := NewAppWithDeps(&MockWAClient{}, mockStore, "/tmp", "test")
+
+	// When: ListChats called
+	result := app.ListChats(nil, 10, 0)
+
+	// Then: Returns chats
+	resp := parseResponse(t, result)
+	require.True(t, resp.Success)
+
+	var chats []store.Chat
+	err := json.Unmarshal(resp.Data, &chats)
+	require.NoError(t, err)
+	require.Len(t, chats, 2)
+}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vicentereig/whatsapp-cli/internal/client"
 	"github.com/vicentereig/whatsapp-cli/internal/output"
 	"github.com/vicentereig/whatsapp-cli/internal/store"
+	"github.com/vicentereig/whatsapp-cli/internal/types"
 	"go.mau.fi/whatsmeow/types/events"
 )
 
@@ -338,7 +339,7 @@ func (a *App) downloadMediaWithClient(ctx context.Context, info store.MessageDow
 	if err := a.client.Connect(ctx); err != nil {
 		return 0, err
 	}
-	req := client.MediaDownloadRequest{
+	req := types.MediaDownloadRequest{
 		DirectPath:    info.DirectPath,
 		MediaKey:      info.MediaKey,
 		FileSHA256:    info.FileSHA256,

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -21,14 +21,15 @@ import (
 )
 
 type App struct {
-	client          *client.WAClient
-	store           *store.MessageStore
+	client          WAClient
+	store           MessageStore
 	version         string
 	storeDir        string
 	mediaDownloader func(ctx context.Context, info store.MessageDownloadInfo, targetPath string) (int64, error)
 	mediaWorker     *mediaDownloadWorker
 }
 
+// NewApp creates a new App with production dependencies.
 func NewApp(storeDir, version string) (*App, error) {
 	cli, err := client.NewWAClient(storeDir)
 	if err != nil {
@@ -49,6 +50,17 @@ func NewApp(storeDir, version string) (*App, error) {
 	}
 	app.mediaDownloader = app.downloadMediaWithClient
 	return app, nil
+}
+
+// NewAppWithDeps creates a new App with injected dependencies for testing.
+func NewAppWithDeps(client WAClient, store MessageStore, storeDir, version string) *App {
+	app := &App{
+		client:   client,
+		store:    store,
+		version:  version,
+		storeDir: storeDir,
+	}
+	return app
 }
 
 func (a *App) Close() {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -141,7 +141,7 @@ func (a *App) SendMessage(ctx context.Context, recipient, message string) string
 	// Store the message
 	timestamp := time.Now()
 	chatJID := recipient
-	if !contains(recipient, "@") {
+	if !strings.Contains(recipient, "@") {
 		chatJID = recipient + "@s.whatsapp.net"
 	}
 
@@ -472,9 +472,9 @@ func (w *mediaDownloadWorker) run() {
 func (w *mediaDownloadWorker) trackError(err error) {
 	errStr := err.Error()
 	// Check for expected expired/deleted media errors
-	isExpired := contains(errStr, "status code 403") ||
-		contains(errStr, "status code 404") ||
-		contains(errStr, "status code 410")
+	isExpired := strings.Contains(errStr, "status code 403") ||
+		strings.Contains(errStr, "status code 404") ||
+		strings.Contains(errStr, "status code 410")
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -539,15 +539,6 @@ func (w *mediaDownloadWorker) Stop() {
 		w.cancel()
 	}
 	w.wg.Wait()
-}
-
-func contains(s, substr string) bool {
-	for i := 0; i < len(s); i++ {
-		if i+len(substr) <= len(s) && s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }
 
 // Sync connects to WhatsApp and continuously syncs messages to the database

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -129,45 +129,91 @@ func (a *App) ListChats(query *string, limit, page int) string {
 	return output.Success(chats)
 }
 
+// recipientToJID normalizes a recipient string to a full JID.
+func recipientToJID(recipient string) string {
+	if strings.Contains(recipient, "@") {
+		return recipient
+	}
+	return recipient + "@s.whatsapp.net"
+}
+
 func (a *App) SendMessage(ctx context.Context, recipient, message string) string {
 	if err := a.client.Connect(ctx); err != nil {
 		return output.Error(err)
 	}
 
-	if err := a.client.SendMessage(ctx, recipient, message); err != nil {
+	msgID, err := a.client.SendMessage(ctx, recipient, message)
+	if err != nil {
 		return output.Error(err)
 	}
 
-	// Store the message
 	timestamp := time.Now()
-	chatJID := recipient
-	if !strings.Contains(recipient, "@") {
-		chatJID = recipient + "@s.whatsapp.net"
-	}
+	chatJID := recipientToJID(recipient)
 
-	// Resolve a friendly chat name when available (falls back to JID/recipient)
 	chatName := a.client.ResolveChatName(ctx, chatJID, nil)
 	if chatName == "" {
 		chatName = recipient
 	}
 
-	// Store chat if needed
-	a.store.StoreChat(chatJID, chatName, timestamp)
-	a.store.StoreMessage(
-		fmt.Sprintf("%d", timestamp.Unix()),
-		chatJID,
-		"me",
-		message,
-		timestamp,
-		true,
+	if err := a.store.StoreChat(chatJID, chatName, timestamp); err != nil {
+		return output.Error(fmt.Errorf("storing chat: %w", err))
+	}
+	if err := a.store.StoreMessage(
+		msgID, chatJID, "me", message, timestamp, true,
 		"", "", "", "", "",
 		nil, nil, nil, 0,
-	)
+	); err != nil {
+		return output.Error(fmt.Errorf("storing message: %w", err))
+	}
 
 	return output.Success(map[string]interface{}{
 		"sent":      true,
+		"id":        msgID,
 		"recipient": recipient,
 		"message":   message,
+	})
+}
+
+func (a *App) SendImage(ctx context.Context, recipient, imagePath, caption string) string {
+	if err := a.client.Connect(ctx); err != nil {
+		return output.Error(err)
+	}
+
+	msgID, err := a.client.SendImageMessage(ctx, recipient, imagePath, caption)
+	if err != nil {
+		return output.Error(err)
+	}
+
+	timestamp := time.Now()
+	chatJID := recipientToJID(recipient)
+
+	chatName := a.client.ResolveChatName(ctx, chatJID, nil)
+	if chatName == "" {
+		chatName = recipient
+	}
+
+	content := caption
+	if content == "" {
+		content = "[Image]"
+	}
+
+	if err := a.store.StoreChat(chatJID, chatName, timestamp); err != nil {
+		return output.Error(fmt.Errorf("storing chat: %w", err))
+	}
+	if err := a.store.StoreMessage(
+		msgID, chatJID, "me", content, timestamp, true,
+		"image", filepath.Base(imagePath), "", "", "",
+		nil, nil, nil, 0,
+	); err != nil {
+		return output.Error(fmt.Errorf("storing message: %w", err))
+	}
+
+	return output.Success(map[string]interface{}{
+		"sent":      true,
+		"id":        msgID,
+		"recipient": recipient,
+		"image":     imagePath,
+		"caption":   caption,
 	})
 }
 

--- a/internal/commands/interfaces.go
+++ b/internal/commands/interfaces.go
@@ -1,16 +1,14 @@
 // Package commands provides the CLI command implementations.
 //
-// # Dependency Injection (Future Work)
+// # Dependency Injection
 //
-// The interfaces below document the dependencies of App.
-// Currently App uses concrete types; these interfaces prepare for
-// future testability improvements where mocks can be injected.
+// The interfaces below define the dependencies of App, enabling testability
+// through mock injection. Types are shared via internal/types to avoid
+// circular dependencies.
 //
-// To fully enable DI:
-// 1. Align MediaDownloadRequest types between client and commands
-// 2. Add StartSync to WAClient interface
-// 3. Update App struct to use interfaces
-// 4. Add constructor that accepts interfaces for testing
+// Usage:
+//   - Production: Use NewApp() which creates concrete implementations
+//   - Testing: Use NewAppWithDeps() to inject mocks
 package commands
 
 import (
@@ -18,6 +16,7 @@ import (
 	"time"
 
 	"github.com/vicentereig/whatsapp-cli/internal/store"
+	"github.com/vicentereig/whatsapp-cli/internal/types"
 )
 
 // MessageStore defines the interface for message persistence.
@@ -45,17 +44,6 @@ type WAClient interface {
 	Disconnect()
 	SendMessage(ctx context.Context, recipient, message string) error
 	ResolveChatName(ctx context.Context, jid string, evt interface{}) string
-	DownloadMediaToFile(ctx context.Context, req MediaDownloadRequest, targetPath string) (int64, error)
-}
-
-// MediaDownloadRequest contains parameters for downloading media.
-type MediaDownloadRequest struct {
-	URL           string
-	DirectPath    string
-	MediaKey      []byte
-	FileSHA256    []byte
-	FileEncSHA256 []byte
-	FileLength    uint64
-	MediaType     string
-	MimeType      string
+	DownloadMediaToFile(ctx context.Context, req types.MediaDownloadRequest, targetPath string) (int64, error)
+	StartSync(ctx context.Context, eventHandler func(interface{})) error
 }

--- a/internal/commands/interfaces.go
+++ b/internal/commands/interfaces.go
@@ -1,0 +1,61 @@
+// Package commands provides the CLI command implementations.
+//
+// # Dependency Injection (Future Work)
+//
+// The interfaces below document the dependencies of App.
+// Currently App uses concrete types; these interfaces prepare for
+// future testability improvements where mocks can be injected.
+//
+// To fully enable DI:
+// 1. Align MediaDownloadRequest types between client and commands
+// 2. Add StartSync to WAClient interface
+// 3. Update App struct to use interfaces
+// 4. Add constructor that accepts interfaces for testing
+package commands
+
+import (
+	"context"
+	"time"
+
+	"github.com/vicentereig/whatsapp-cli/internal/store"
+)
+
+// MessageStore defines the interface for message persistence.
+// The concrete implementation is store.MessageStore.
+// Defined here (at consumer) per Go best practice: "Accept interfaces, return concrete types"
+type MessageStore interface {
+	ListMessages(params store.ListMessagesParams) ([]store.Message, error)
+	SearchContacts(query string) ([]store.Contact, error)
+	ListChats(params store.ListChatsParams) ([]store.Chat, error)
+	StoreChat(jid, name string, lastMessageTime time.Time) error
+	StoreMessage(id, chatJID, sender, content string, timestamp time.Time, isFromMe bool,
+		mediaType, filename, url, directPath, mimeType string,
+		mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64) error
+	GetMessageForDownload(id string, chatJID *string) (store.MessageDownloadInfo, error)
+	MarkMediaDownloaded(id, chatJID, localPath string, downloadedAt time.Time) error
+	Close() error
+}
+
+// WAClient defines the interface for WhatsApp client operations.
+// The concrete implementation is client.WAClient.
+type WAClient interface {
+	IsAuthenticated() bool
+	Authenticate(ctx context.Context) error
+	Connect(ctx context.Context) error
+	Disconnect()
+	SendMessage(ctx context.Context, recipient, message string) error
+	ResolveChatName(ctx context.Context, jid string, evt interface{}) string
+	DownloadMediaToFile(ctx context.Context, req MediaDownloadRequest, targetPath string) (int64, error)
+}
+
+// MediaDownloadRequest contains parameters for downloading media.
+type MediaDownloadRequest struct {
+	URL           string
+	DirectPath    string
+	MediaKey      []byte
+	FileSHA256    []byte
+	FileEncSHA256 []byte
+	FileLength    uint64
+	MediaType     string
+	MimeType      string
+}

--- a/internal/commands/interfaces.go
+++ b/internal/commands/interfaces.go
@@ -42,7 +42,8 @@ type WAClient interface {
 	Authenticate(ctx context.Context) error
 	Connect(ctx context.Context) error
 	Disconnect()
-	SendMessage(ctx context.Context, recipient, message string) error
+	SendMessage(ctx context.Context, recipient, message string) (string, error)
+	SendImageMessage(ctx context.Context, recipient, imagePath, caption string) (string, error)
 	ResolveChatName(ctx context.Context, jid string, evt interface{}) string
 	DownloadMediaToFile(ctx context.Context, req types.MediaDownloadRequest, targetPath string) (int64, error)
 	StartSync(ctx context.Context, eventHandler func(interface{})) error

--- a/internal/commands/mocks_test.go
+++ b/internal/commands/mocks_test.go
@@ -1,0 +1,144 @@
+package commands
+
+import (
+	"context"
+	"time"
+
+	"github.com/vicentereig/whatsapp-cli/internal/store"
+	"github.com/vicentereig/whatsapp-cli/internal/types"
+)
+
+// MockMessageStore implements MessageStore for testing.
+type MockMessageStore struct {
+	ListMessagesFunc        func(params store.ListMessagesParams) ([]store.Message, error)
+	SearchContactsFunc      func(query string) ([]store.Contact, error)
+	ListChatsFunc           func(params store.ListChatsParams) ([]store.Chat, error)
+	StoreChatFunc           func(jid, name string, lastMessageTime time.Time) error
+	StoreMessageFunc        func(id, chatJID, sender, content string, timestamp time.Time, isFromMe bool, mediaType, filename, url, directPath, mimeType string, mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64) error
+	GetMessageForDownloadFunc func(id string, chatJID *string) (store.MessageDownloadInfo, error)
+	MarkMediaDownloadedFunc func(id, chatJID, localPath string, downloadedAt time.Time) error
+	CloseFunc               func() error
+}
+
+func (m *MockMessageStore) ListMessages(params store.ListMessagesParams) ([]store.Message, error) {
+	if m.ListMessagesFunc != nil {
+		return m.ListMessagesFunc(params)
+	}
+	return nil, nil
+}
+
+func (m *MockMessageStore) SearchContacts(query string) ([]store.Contact, error) {
+	if m.SearchContactsFunc != nil {
+		return m.SearchContactsFunc(query)
+	}
+	return nil, nil
+}
+
+func (m *MockMessageStore) ListChats(params store.ListChatsParams) ([]store.Chat, error) {
+	if m.ListChatsFunc != nil {
+		return m.ListChatsFunc(params)
+	}
+	return nil, nil
+}
+
+func (m *MockMessageStore) StoreChat(jid, name string, lastMessageTime time.Time) error {
+	if m.StoreChatFunc != nil {
+		return m.StoreChatFunc(jid, name, lastMessageTime)
+	}
+	return nil
+}
+
+func (m *MockMessageStore) StoreMessage(id, chatJID, sender, content string, timestamp time.Time, isFromMe bool, mediaType, filename, url, directPath, mimeType string, mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64) error {
+	if m.StoreMessageFunc != nil {
+		return m.StoreMessageFunc(id, chatJID, sender, content, timestamp, isFromMe, mediaType, filename, url, directPath, mimeType, mediaKey, fileSHA256, fileEncSHA256, fileLength)
+	}
+	return nil
+}
+
+func (m *MockMessageStore) GetMessageForDownload(id string, chatJID *string) (store.MessageDownloadInfo, error) {
+	if m.GetMessageForDownloadFunc != nil {
+		return m.GetMessageForDownloadFunc(id, chatJID)
+	}
+	return store.MessageDownloadInfo{}, nil
+}
+
+func (m *MockMessageStore) MarkMediaDownloaded(id, chatJID, localPath string, downloadedAt time.Time) error {
+	if m.MarkMediaDownloadedFunc != nil {
+		return m.MarkMediaDownloadedFunc(id, chatJID, localPath, downloadedAt)
+	}
+	return nil
+}
+
+func (m *MockMessageStore) Close() error {
+	if m.CloseFunc != nil {
+		return m.CloseFunc()
+	}
+	return nil
+}
+
+// MockWAClient implements WAClient for testing.
+type MockWAClient struct {
+	IsAuthenticatedFunc     func() bool
+	AuthenticateFunc        func(ctx context.Context) error
+	ConnectFunc             func(ctx context.Context) error
+	DisconnectFunc          func()
+	SendMessageFunc         func(ctx context.Context, recipient, message string) error
+	ResolveChatNameFunc     func(ctx context.Context, jid string, evt interface{}) string
+	DownloadMediaToFileFunc func(ctx context.Context, req types.MediaDownloadRequest, targetPath string) (int64, error)
+	StartSyncFunc           func(ctx context.Context, eventHandler func(interface{})) error
+}
+
+func (m *MockWAClient) IsAuthenticated() bool {
+	if m.IsAuthenticatedFunc != nil {
+		return m.IsAuthenticatedFunc()
+	}
+	return true
+}
+
+func (m *MockWAClient) Authenticate(ctx context.Context) error {
+	if m.AuthenticateFunc != nil {
+		return m.AuthenticateFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockWAClient) Connect(ctx context.Context) error {
+	if m.ConnectFunc != nil {
+		return m.ConnectFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockWAClient) Disconnect() {
+	if m.DisconnectFunc != nil {
+		m.DisconnectFunc()
+	}
+}
+
+func (m *MockWAClient) SendMessage(ctx context.Context, recipient, message string) error {
+	if m.SendMessageFunc != nil {
+		return m.SendMessageFunc(ctx, recipient, message)
+	}
+	return nil
+}
+
+func (m *MockWAClient) ResolveChatName(ctx context.Context, jid string, evt interface{}) string {
+	if m.ResolveChatNameFunc != nil {
+		return m.ResolveChatNameFunc(ctx, jid, evt)
+	}
+	return jid
+}
+
+func (m *MockWAClient) DownloadMediaToFile(ctx context.Context, req types.MediaDownloadRequest, targetPath string) (int64, error) {
+	if m.DownloadMediaToFileFunc != nil {
+		return m.DownloadMediaToFileFunc(ctx, req, targetPath)
+	}
+	return 0, nil
+}
+
+func (m *MockWAClient) StartSync(ctx context.Context, eventHandler func(interface{})) error {
+	if m.StartSyncFunc != nil {
+		return m.StartSyncFunc(ctx, eventHandler)
+	}
+	return nil
+}

--- a/internal/commands/mocks_test.go
+++ b/internal/commands/mocks_test.go
@@ -82,7 +82,8 @@ type MockWAClient struct {
 	AuthenticateFunc        func(ctx context.Context) error
 	ConnectFunc             func(ctx context.Context) error
 	DisconnectFunc          func()
-	SendMessageFunc         func(ctx context.Context, recipient, message string) error
+	SendMessageFunc         func(ctx context.Context, recipient, message string) (string, error)
+	SendImageMessageFunc    func(ctx context.Context, recipient, imagePath, caption string) (string, error)
 	ResolveChatNameFunc     func(ctx context.Context, jid string, evt interface{}) string
 	DownloadMediaToFileFunc func(ctx context.Context, req types.MediaDownloadRequest, targetPath string) (int64, error)
 	StartSyncFunc           func(ctx context.Context, eventHandler func(interface{})) error
@@ -115,11 +116,18 @@ func (m *MockWAClient) Disconnect() {
 	}
 }
 
-func (m *MockWAClient) SendMessage(ctx context.Context, recipient, message string) error {
+func (m *MockWAClient) SendMessage(ctx context.Context, recipient, message string) (string, error) {
 	if m.SendMessageFunc != nil {
 		return m.SendMessageFunc(ctx, recipient, message)
 	}
-	return nil
+	return "mock-id", nil
+}
+
+func (m *MockWAClient) SendImageMessage(ctx context.Context, recipient, imagePath, caption string) (string, error) {
+	if m.SendImageMessageFunc != nil {
+		return m.SendImageMessageFunc(ctx, recipient, imagePath, caption)
+	}
+	return "mock-id", nil
 }
 
 func (m *MockWAClient) ResolveChatName(ctx context.Context, jid string, evt interface{}) string {

--- a/internal/types/media.go
+++ b/internal/types/media.go
@@ -1,0 +1,17 @@
+// Package types provides shared data structures used across packages.
+// This enables dependency inversion: both client and commands import types,
+// rather than commands importing client.
+package types
+
+// MediaDownloadRequest contains parameters for downloading media from WhatsApp.
+// Used by both client (to perform download) and commands (to request download).
+type MediaDownloadRequest struct {
+	URL           string
+	DirectPath    string
+	MediaKey      []byte
+	FileSHA256    []byte
+	FileEncSHA256 []byte
+	FileLength    uint64
+	MediaType     string
+	MimeType      string
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,11 @@ var (
 	version = "1.3.1"
 )
 
+const (
+	// defaultTimeout is the maximum duration for non-sync commands
+	defaultTimeout = 5 * time.Minute
+)
+
 const usage = `WhatsApp CLI - Command line interface for WhatsApp
 
 Usage:
@@ -99,7 +104,7 @@ func main() {
 			cancel()
 		}()
 	} else {
-		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel = context.WithTimeout(context.Background(), defaultTimeout)
 	}
 	defer cancel()
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,15 @@ const (
 	defaultTimeout = 5 * time.Minute
 )
 
+// optionalStr returns nil for empty strings, otherwise a pointer to the string.
+// Used to convert flag values to optional parameters.
+func optionalStr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
 const usage = `WhatsApp CLI - Command line interface for WhatsApp
 
 Usage:
@@ -132,11 +141,7 @@ func main() {
 		if subcommand == "search" || *query != "" {
 			result = app.ListMessages(nil, query, *limit, *page)
 		} else {
-			var chatPtr *string
-			if *chatJID != "" {
-				chatPtr = chatJID
-			}
-			result = app.ListMessages(chatPtr, nil, *limit, *page)
+			result = app.ListMessages(optionalStr(*chatJID), nil, *limit, *page)
 		}
 
 	case "contacts":
@@ -157,11 +162,7 @@ func main() {
 		page := chatsCmd.Int("page", 0, "page")
 		chatsCmd.Parse(args[2:]) // skip "chats" and "list"
 
-		var queryPtr *string
-		if *query != "" {
-			queryPtr = query
-		}
-		result = app.ListChats(queryPtr, *limit, *page)
+		result = app.ListChats(optionalStr(*query), *limit, *page)
 
 	case "send":
 		sendCmd := flag.NewFlagSet("send", flag.ExitOnError)
@@ -190,11 +191,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, `{"success":false,"data":null,"error":"--message-id required"}`)
 			os.Exit(1)
 		}
-		var chatPtr *string
-		if *chatJID != "" {
-			chatPtr = chatJID
-		}
-		result = app.DownloadMedia(ctx, *messageID, chatPtr, *outputPath)
+		result = app.DownloadMedia(ctx, *messageID, optionalStr(*chatJID), *outputPath)
 
 	default:
 		fmt.Fprintf(os.Stderr, `{"success":false,"data":null,"error":"Unknown command: %s"}

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 		query := messagesCmd.String("query", "", "search query")
 		limit := messagesCmd.Int("limit", 20, "limit")
 		page := messagesCmd.Int("page", 0, "page")
-		messagesCmd.Parse(args[1:])
+		messagesCmd.Parse(args[2:]) // skip "messages" and subcommand ("list" or "search")
 
 		if subcommand == "search" || *query != "" {
 			result = app.ListMessages(nil, query, *limit, *page)
@@ -133,7 +133,7 @@ func main() {
 	case "contacts":
 		contactsCmd := flag.NewFlagSet("contacts", flag.ExitOnError)
 		query := contactsCmd.String("query", "", "search query")
-		contactsCmd.Parse(args[1:])
+		contactsCmd.Parse(args[2:]) // skip "contacts" and "search"
 
 		if *query == "" {
 			fmt.Fprintln(os.Stderr, `{"success":false,"data":null,"error":"--query required"}`)
@@ -146,7 +146,7 @@ func main() {
 		query := chatsCmd.String("query", "", "search query")
 		limit := chatsCmd.Int("limit", 20, "limit")
 		page := chatsCmd.Int("page", 0, "page")
-		chatsCmd.Parse(args[1:])
+		chatsCmd.Parse(args[2:]) // skip "chats" and "list"
 
 		var queryPtr *string
 		if *query != "" {

--- a/main.go
+++ b/main.go
@@ -82,7 +82,11 @@ func main() {
 	}
 
 	// Create app
-	absStoreDir, _ := filepath.Abs(*storeDir)
+	absStoreDir, err := filepath.Abs(*storeDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, `{"success":false,"data":null,"error":"invalid store path: %v"}`+"\n", err)
+		os.Exit(1)
+	}
 	app, err := commands.NewApp(absStoreDir, version)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, `{"success":false,"data":null,"error":"Failed to initialize: %v"}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -44,7 +45,8 @@ Commands:
   messages search --query TEXT      Search messages
   contacts search --query TEXT      Search contacts
   chats list                        List chats
-  send --to RECIPIENT --message TEXT    Send a message
+  send --to RECIPIENT --message TEXT                     Send a text message
+  send --to RECIPIENT --image PATH [--caption TEXT]      Send an image
   media download --message-id ID [--chat JID] [--output PATH]   Download media for a message
   version                           Print CLI version information
 
@@ -61,28 +63,60 @@ Examples:
   whatsapp-cli send --to 1234567890@g.us --message "Hello group"
 `
 
+// extractGlobalFlags pulls --store from anywhere in the arg list,
+// returning the store directory and remaining args.
+func extractGlobalFlags(args []string) (string, []string) {
+	storeDir := "./store"
+	var remaining []string
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--store" && i+1 < len(args):
+			storeDir = args[i+1]
+			i++ // skip value
+		case strings.HasPrefix(args[i], "--store="):
+			storeDir = strings.TrimPrefix(args[i], "--store=")
+		default:
+			remaining = append(remaining, args[i])
+		}
+	}
+	return storeDir, remaining
+}
+
+func exitJSON(msg string) {
+	fmt.Fprintf(os.Stderr, `{"success":false,"data":null,"error":"%s"}`+"\n", msg)
+	os.Exit(1)
+}
+
+func requireSubcommand(args []string, command string, valid []string) string {
+	if len(args) < 2 {
+		exitJSON(fmt.Sprintf("%s requires a subcommand: %s", command, strings.Join(valid, ", ")))
+	}
+	sub := args[1]
+	for _, v := range valid {
+		if sub == v {
+			return sub
+		}
+	}
+	exitJSON(fmt.Sprintf("unknown %s subcommand: %s (valid: %s)", command, sub, strings.Join(valid, ", ")))
+	return "" // unreachable
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprint(os.Stderr, usage)
 		os.Exit(1)
 	}
 
-	// Global flags
-	storeDir := flag.String("store", "./store", "storage directory")
-	flag.Parse()
+	// Extract --store from anywhere in args,
+	// so "whatsapp-cli contacts search --store /tmp" works.
+	storeDir, args := extractGlobalFlags(os.Args[1:])
 
-	// Get command
-	args := flag.Args()
 	if len(args) == 0 {
 		fmt.Fprint(os.Stderr, usage)
 		os.Exit(1)
 	}
 
 	command := args[0]
-	subcommand := ""
-	if len(args) > 1 {
-		subcommand = args[1]
-	}
 
 	if command == "version" {
 		fmt.Printf(`{"success":true,"data":{"version":"%s"},"error":null}
@@ -91,7 +125,7 @@ func main() {
 	}
 
 	// Create app
-	absStoreDir, err := filepath.Abs(*storeDir)
+	absStoreDir, err := filepath.Abs(storeDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, `{"success":false,"data":null,"error":"invalid store path: %v"}`+"\n", err)
 		os.Exit(1)
@@ -131,36 +165,42 @@ func main() {
 		result = app.Sync(ctx)
 
 	case "messages":
+		subcommand := requireSubcommand(args, "messages", []string{"list", "search"})
 		messagesCmd := flag.NewFlagSet("messages", flag.ExitOnError)
 		chatJID := messagesCmd.String("chat", "", "chat JID")
 		query := messagesCmd.String("query", "", "search query")
 		limit := messagesCmd.Int("limit", 20, "limit")
 		page := messagesCmd.Int("page", 0, "page")
-		messagesCmd.Parse(args[2:]) // skip "messages" and subcommand ("list" or "search")
+		messagesCmd.Parse(args[2:])
 
-		if subcommand == "search" || *query != "" {
+		switch subcommand {
+		case "search":
+			if *query == "" {
+				exitJSON("messages search requires --query")
+			}
 			result = app.ListMessages(nil, query, *limit, *page)
-		} else {
+		case "list":
 			result = app.ListMessages(optionalStr(*chatJID), nil, *limit, *page)
 		}
 
 	case "contacts":
+		requireSubcommand(args, "contacts", []string{"search"})
 		contactsCmd := flag.NewFlagSet("contacts", flag.ExitOnError)
 		query := contactsCmd.String("query", "", "search query")
-		contactsCmd.Parse(args[2:]) // skip "contacts" and "search"
+		contactsCmd.Parse(args[2:])
 
 		if *query == "" {
-			fmt.Fprintln(os.Stderr, `{"success":false,"data":null,"error":"--query required"}`)
-			os.Exit(1)
+			exitJSON("contacts search requires --query")
 		}
 		result = app.SearchContacts(*query)
 
 	case "chats":
+		requireSubcommand(args, "chats", []string{"list"})
 		chatsCmd := flag.NewFlagSet("chats", flag.ExitOnError)
 		query := chatsCmd.String("query", "", "search query")
 		limit := chatsCmd.Int("limit", 20, "limit")
 		page := chatsCmd.Int("page", 0, "page")
-		chatsCmd.Parse(args[2:]) // skip "chats" and "list"
+		chatsCmd.Parse(args[2:])
 
 		result = app.ListChats(optionalStr(*query), *limit, *page)
 
@@ -168,19 +208,26 @@ func main() {
 		sendCmd := flag.NewFlagSet("send", flag.ExitOnError)
 		to := sendCmd.String("to", "", "recipient")
 		message := sendCmd.String("message", "", "message text")
+		image := sendCmd.String("image", "", "image file path")
+		caption := sendCmd.String("caption", "", "image caption")
 		sendCmd.Parse(args[1:])
 
-		if *to == "" || *message == "" {
-			fmt.Fprintln(os.Stderr, `{"success":false,"data":null,"error":"--to and --message required"}`)
-			os.Exit(1)
+		if *to == "" {
+			exitJSON(`--to is required`)
 		}
-		result = app.SendMessage(ctx, *to, *message)
+		if *image != "" && *message != "" {
+			exitJSON(`--message and --image are mutually exclusive`)
+		}
+		if *image != "" {
+			result = app.SendImage(ctx, *to, *image, *caption)
+		} else if *message != "" {
+			result = app.SendMessage(ctx, *to, *message)
+		} else {
+			exitJSON(`--message or --image required`)
+		}
 
 	case "media":
-		if subcommand != "download" {
-			fmt.Fprintf(os.Stderr, "{\"success\":false,\"data\":null,\"error\":\"Unknown media subcommand: %s\"}\n", subcommand)
-			os.Exit(1)
-		}
+		requireSubcommand(args, "media", []string{"download"})
 		downCmd := flag.NewFlagSet("media download", flag.ExitOnError)
 		messageID := downCmd.String("message-id", "", "message identifier")
 		chatJID := downCmd.String("chat", "", "chat JID (optional)")
@@ -188,8 +235,7 @@ func main() {
 		downCmd.Parse(args[2:])
 
 		if *messageID == "" {
-			fmt.Fprintln(os.Stderr, `{"success":false,"data":null,"error":"--message-id required"}`)
-			os.Exit(1)
+			exitJSON("--message-id required")
 		}
 		result = app.DownloadMedia(ctx, *messageID, optionalStr(*chatJID), *outputPath)
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFlagParsingWithSubcommand demonstrates the bug where flags after a
+// subcommand like "list" are not parsed because Go's flag parser stops at
+// the first non-flag argument.
+func TestFlagParsingWithSubcommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string // simulates args after global flag parsing
+		skipN    int      // how many args to skip before parsing flags
+		wantChat string
+	}{
+		{
+			name:     "bug: args[1:] does not parse --chat after 'list' subcommand",
+			args:     []string{"messages", "list", "--chat", "123@s.whatsapp.net", "--limit", "10"},
+			skipN:    1,  // skip "messages", parse ["list", "--chat", ...]
+			wantChat: "", // BUG: flag not parsed because "list" stops parsing
+		},
+		{
+			name:     "fix: args[2:] correctly parses --chat after skipping subcommand",
+			args:     []string{"messages", "list", "--chat", "123@s.whatsapp.net", "--limit", "10"},
+			skipN:    2,                    // skip "messages" and "list", parse ["--chat", ...]
+			wantChat: "123@s.whatsapp.net", // correctly parsed
+		},
+		{
+			name:     "search subcommand with query flag",
+			args:     []string{"messages", "search", "--query", "hello"},
+			skipN:    2,
+			wantChat: "", // no chat specified, but query should work
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			chatJID := fs.String("chat", "", "chat JID")
+			fs.String("query", "", "search query")
+			fs.Int("limit", 20, "limit")
+			fs.Int("page", 0, "page")
+
+			err := fs.Parse(tt.args[tt.skipN:])
+			require.NoError(t, err)
+			require.Equal(t, tt.wantChat, *chatJID)
+		})
+	}
+}
+
+// TestIssue5_FlagsNotParsed tests the exact scenarios reported in GitHub issue #5:
+// - "contacts search --query abhi" returned "query required" error
+// - "chats list --limit 1" ignored the limit flag
+// See: https://github.com/vicentereig/whatsapp-cli/issues/5
+func TestIssue5_FlagsNotParsed(t *testing.T) {
+	t.Run("contacts search --query should parse query flag", func(t *testing.T) {
+		// Issue #5: `whatsapp-cli contacts search --query "abhi"` returned
+		// {"success":false,"data":null,"error":"--query required"}
+		args := []string{"contacts", "search", "--query", "abhi"}
+
+		fs := flag.NewFlagSet("contacts", flag.ContinueOnError)
+		query := fs.String("query", "", "search query")
+
+		// With the fix: skip 2 args (command + subcommand)
+		err := fs.Parse(args[2:])
+		require.NoError(t, err)
+		require.Equal(t, "abhi", *query, "query flag should be parsed")
+	})
+
+	t.Run("chats list --limit should parse limit flag", func(t *testing.T) {
+		// Issue #5: `whatsapp-cli chats list --limit 1` showed all 20 results
+		args := []string{"chats", "list", "--limit", "1"}
+
+		fs := flag.NewFlagSet("chats", flag.ContinueOnError)
+		fs.String("query", "", "")
+		limit := fs.Int("limit", 20, "limit")
+		fs.Int("page", 0, "")
+
+		// With the fix: skip 2 args (command + subcommand)
+		err := fs.Parse(args[2:])
+		require.NoError(t, err)
+		require.Equal(t, 1, *limit, "limit flag should be parsed as 1, not default 20")
+	})
+
+	t.Run("messages list --chat should parse chat filter", func(t *testing.T) {
+		// Related: messages list --chat JID was returning unfiltered results
+		args := []string{"messages", "list", "--chat", "123456@s.whatsapp.net", "--limit", "5"}
+
+		fs := flag.NewFlagSet("messages", flag.ContinueOnError)
+		chat := fs.String("chat", "", "chat JID")
+		fs.String("query", "", "")
+		limit := fs.Int("limit", 20, "limit")
+		fs.Int("page", 0, "")
+
+		// With the fix: skip 2 args (command + subcommand)
+		err := fs.Parse(args[2:])
+		require.NoError(t, err)
+		require.Equal(t, "123456@s.whatsapp.net", *chat, "chat flag should be parsed")
+		require.Equal(t, 5, *limit, "limit flag should be parsed")
+	})
+}
+
+// TestSubcommandArgSkipping verifies the correct number of args to skip
+// for each command type.
+func TestSubcommandArgSkipping(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantChat  string
+		wantQuery string
+	}{
+		{
+			name:      "messages list --chat requires skipping 2 args",
+			args:      []string{"messages", "list", "--chat", "test@jid"},
+			wantChat:  "test@jid",
+			wantQuery: "",
+		},
+		{
+			name:      "messages search --query requires skipping 2 args",
+			args:      []string{"messages", "search", "--query", "hello"},
+			wantChat:  "",
+			wantQuery: "hello",
+		},
+		{
+			name:      "chats list --query requires skipping 2 args",
+			args:      []string{"chats", "list", "--query", "test"},
+			wantChat:  "",
+			wantQuery: "test",
+		},
+		{
+			name:      "contacts search --query requires skipping 2 args",
+			args:      []string{"contacts", "search", "--query", "john"},
+			wantChat:  "",
+			wantQuery: "john",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet(tt.name, flag.ContinueOnError)
+			chat := fs.String("chat", "", "chat JID")
+			query := fs.String("query", "", "search query")
+			fs.Int("limit", 20, "")
+			fs.Int("page", 0, "")
+
+			// Skip 2 args (command + subcommand) to correctly parse flags
+			err := fs.Parse(tt.args[2:])
+			require.NoError(t, err)
+			require.Equal(t, tt.wantChat, *chat, "chat flag")
+			require.Equal(t, tt.wantQuery, *query, "query flag")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Flag parsing fix**: Parse flags after subcommand, not before (closes #5)
- **DI refactor**: Extract WAClient and MessageStore interfaces for testability, add behavioral tests with mocks
- **Image sending**: `send --to RECIPIENT --image PATH [--caption TEXT]` via whatsmeow Upload API
- **Robustness fixes**: Handle filepath.Abs errors, replace custom contains(), extract constants, mutual exclusion for `--image`/`--message`, real message IDs from whatsmeow

## Test plan

- [x] `go test -race ./...` passes (all packages)
- [x] `go vet ./...` clean
- [x] Manual verification against real WhatsApp store
- [x] Image sending tested end-to-end (JPEG upload + delivery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)